### PR TITLE
BUG-001: New Expenses Not Appearing at Top of List

### DIFF
--- a/backend/app/controllers/api/expenses_controller.rb
+++ b/backend/app/controllers/api/expenses_controller.rb
@@ -1,6 +1,6 @@
 class Api::ExpensesController < ApplicationController
   def index
-    expenses = Expense.includes(:category).order(created_at: :desc)
+    expenses = Expense.includes(:category).order(date: :desc, created_at: :desc)
 
     if params[:year].present? && params[:month].present?
       year = params[:year].to_i


### PR DESCRIPTION
Fixes expenses not appearing at the top of the list when a date is manually 
set on creation. Closes [#BUG-001](https://github.com/iam7kei/likhait-technical-test/issues/1).

## What Changed
- Added `date: :desc` as the primary sort key in the expenses query
- `created_at: :desc` is now the tiebreaker for same-day expenses

## Root Cause
Expenses were only ordered by `created_at`, so backdated or manually-dated 
expenses would appear out of order instead of at the top.

## Testing
1. Create a new expense with today's date
2. Verify it appears at the top of the list
3. Create an expense with a past date
4. Verify it sorts correctly below newer dates
5. Create two expenses on the same date — verify the most recently entered appears first

## Notes
- Low risk change, single query argument order update
- No schema or API changes