### PR TITLE
BONUS-001: Prevent future date expense creation

### DIFF
--- a/backend/app/controllers/api/expenses_controller.rb
+++ b/backend/app/controllers/api/expenses_controller.rb
@@ -21,7 +21,7 @@ class Api::ExpensesController < ApplicationController
     if expense.save
       render json: format_expense(expense), status: :created
     else
-      render json: { errors: expense.errors.full_messages }, status: :unprocessable_entity
+      render json: { full_message: expense.errors.full_messages, errors: format_errors(expense) }, status: :unprocessable_entity
     end
   end
 
@@ -57,5 +57,11 @@ class Api::ExpensesController < ApplicationController
       created_at: expense.created_at,
       updated_at: expense.updated_at
     }
+  end
+
+  def format_errors(expense)
+    expense.errors.map do |error|
+      { field: error.attribute.to_s, message: error.message }
+    end
   end
 end

--- a/backend/app/models/expense.rb
+++ b/backend/app/models/expense.rb
@@ -1,3 +1,13 @@
 class Expense < ApplicationRecord
   belongs_to :category
+  validate :date_cannot_be_in_future
+
+  private
+
+  def date_cannot_be_in_future
+    if date.present? && date > Date.today
+
+      errors.add(:date, "Date cannot be in the future")
+    end
+  end
 end

--- a/frontend/src/components/ExpenseForm.tsx
+++ b/frontend/src/components/ExpenseForm.tsx
@@ -9,106 +9,108 @@ import { TextField, SelectBox, Button } from "../vibes";
 import { useExpenseForm } from "../hooks/useExpenseForm";
 
 interface ExpenseFormProps {
-  initialData?: Partial<ExpenseFormData>;
-  onSubmit: (data: ExpenseFormData) => Promise<void>;
-  onCancel?: () => void;
-  submitLabel?: string;
+    initialData?: Partial<ExpenseFormData>;
+    onSubmit: (data: ExpenseFormData) => Promise<void>;
+    onCancel?: () => void;
+    submitLabel?: string;
 }
 
 export function ExpenseForm({
-  initialData,
-  onSubmit,
-  onCancel,
-  submitLabel = "Add Expense",
+    initialData,
+    onSubmit,
+    onCancel,
+    submitLabel = "Add Expense",
 }: ExpenseFormProps) {
-  const { formData, errors, isSubmitting, handleChange, handleSubmit } =
-    useExpenseForm({
-      initialData,
-      onSubmit,
-    });
+    const today = new Date().toISOString().split("T")[0];
+    const { formData, errors, isSubmitting, handleChange, handleSubmit } =
+        useExpenseForm({
+            initialData,
+            onSubmit,
+        });
 
-  const formStyle: React.CSSProperties = {
-    display: "flex",
-    flexDirection: "column",
-    gap: "1rem",
-  };
+    const formStyle: React.CSSProperties = {
+        display: "flex",
+        flexDirection: "column",
+        gap: "1rem",
+    };
 
-  const buttonGroupStyle: React.CSSProperties = {
-    display: "flex",
-    gap: "0.5rem",
-    marginTop: "0.5rem",
-  };
+    const buttonGroupStyle: React.CSSProperties = {
+        display: "flex",
+        gap: "0.5rem",
+        marginTop: "0.5rem",
+    };
 
-  const categoryOptions = EXPENSE_CATEGORIES.map((category) => ({
-    value: category,
-    label: category,
-  }));
+    const categoryOptions = EXPENSE_CATEGORIES.map((category) => ({
+        value: category,
+        label: category,
+    }));
 
-  return (
-    <form onSubmit={handleSubmit} style={formStyle}>
-      <TextField
-        label="Amount"
-        type="number"
-        step="0.01"
-        placeholder="0.00"
-        value={formData.amount}
-        onChange={(e) => handleChange("amount", e.target.value)}
-        error={errors.amount}
-        fullWidth
-        required
-      />
+    return (
+        <form onSubmit={handleSubmit} style={formStyle}>
+            <TextField
+                label="Amount"
+                type="number"
+                step="0.01"
+                placeholder="0.00"
+                value={formData.amount}
+                onChange={(e) => handleChange("amount", e.target.value)}
+                error={errors.amount}
+                fullWidth
+                required
+            />
 
-      <TextField
-        label="Description"
-        type="text"
-        placeholder="Enter description"
-        value={formData.description}
-        onChange={(e) => handleChange("description", e.target.value)}
-        error={errors.description}
-        fullWidth
-        required
-      />
+            <TextField
+                label="Description"
+                type="text"
+                placeholder="Enter description"
+                value={formData.description}
+                onChange={(e) => handleChange("description", e.target.value)}
+                error={errors.description}
+                fullWidth
+                required
+            />
 
-      <SelectBox
-        label="Category"
-        options={categoryOptions}
-        value={formData.category}
-        onChange={(e) => handleChange("category", e.target.value)}
-        error={errors.category}
-        fullWidth
-        required
-      />
+            <SelectBox
+                label="Category"
+                options={categoryOptions}
+                value={formData.category}
+                onChange={(e) => handleChange("category", e.target.value)}
+                error={errors.category}
+                fullWidth
+                required
+            />
 
-      <TextField
-        label="Date"
-        type="date"
-        value={formData.date}
-        onChange={(e) => handleChange("date", e.target.value)}
-        error={errors.date}
-        fullWidth
-        required
-      />
+            <TextField
+                label="Date"
+                type="date"
+                value={formData.date}
+                onChange={(e) => handleChange("date", e.target.value)}
+                error={errors.date}
+                max={today}
+                fullWidth
+                required
+            />
 
-      <div style={buttonGroupStyle}>
-        <Button
-          type="submit"
-          variant="primary"
-          disabled={isSubmitting}
-          fullWidth
-        >
-          {isSubmitting ? "Submitting..." : submitLabel}
-        </Button>
-        {onCancel && (
-          <Button
-            type="button"
-            variant="secondary"
-            onClick={onCancel}
-            disabled={isSubmitting}
-          >
-            Cancel
-          </Button>
-        )}
-      </div>
-    </form>
-  );
+            <div style={buttonGroupStyle}>
+                <Button
+                    type="submit"
+                    variant="primary"
+                    disabled={isSubmitting}
+                    fullWidth
+                >
+                    {isSubmitting ? "Submitting..." : submitLabel}
+                </Button>
+                {onCancel && (
+                    <Button
+                        type="button"
+                        variant="secondary"
+                        onClick={onCancel}
+                        disabled={isSubmitting}
+                    >
+                        Cancel
+                    </Button>
+                )}
+            </div>
+        </form>
+    );
 }

--- a/frontend/src/hooks/useExpenseForm.ts
+++ b/frontend/src/hooks/useExpenseForm.ts
@@ -7,93 +7,96 @@ import { ExpenseFormData } from "../types";
 import { formatDate } from "../utils/expenseUtils";
 
 interface UseExpenseFormProps {
-  initialData?: Partial<ExpenseFormData>;
-  onSubmit: (data: ExpenseFormData) => Promise<void>;
+    initialData?: Partial<ExpenseFormData>;
+    onSubmit: (data: ExpenseFormData) => Promise<void>;
 }
 
 export function useExpenseForm({ initialData, onSubmit }: UseExpenseFormProps) {
-  const [formData, setFormData] = useState<ExpenseFormData>({
-    amount: initialData?.amount || "",
-    description: initialData?.description || "",
-    category: initialData?.category || "",
-    date: initialData?.date || formatDate(new Date()),
-  });
-
-  const [errors, setErrors] = useState<Partial<ExpenseFormData>>({});
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleChange = (field: keyof ExpenseFormData, value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    // Clear error for this field when user starts typing
-    if (errors[field]) {
-      setErrors((prev) => ({ ...prev, [field]: undefined }));
-    }
-  };
-
-  const validateForm = (): boolean => {
-    const newErrors: Partial<ExpenseFormData> = {};
-
-    if (!formData.amount || Number(formData.amount) <= 0) {
-      newErrors.amount = "Amount must be greater than 0";
-    }
-
-    if (!formData.description.trim()) {
-      newErrors.description = "Description is required";
-    }
-
-    if (!formData.category) {
-      newErrors.category = "Category is required";
-    }
-
-    if (!formData.date) {
-      newErrors.date = "Date is required";
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!validateForm()) {
-      return;
-    }
-
-    setIsSubmitting(true);
-    try {
-      await onSubmit(formData);
-      // Reset form on success
-      setFormData({
-        amount: "",
-        description: "",
-        category: "",
-        date: formatDate(new Date()),
-      });
-      setErrors({});
-    } catch (error) {
-      console.error("Form submission error:", error);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const resetForm = () => {
-    setFormData({
-      amount: initialData?.amount || "",
-      description: initialData?.description || "",
-      category: initialData?.category || "",
-      date: initialData?.date || formatDate(new Date()),
+    const today = new Date().toISOString().split("T")[0];
+    const [formData, setFormData] = useState<ExpenseFormData>({
+        amount: initialData?.amount || "",
+        description: initialData?.description || "",
+        category: initialData?.category || "",
+        date: initialData?.date || formatDate(new Date()),
     });
-    setErrors({});
-  };
 
-  return {
-    formData,
-    errors,
-    isSubmitting,
-    handleChange,
-    handleSubmit,
-    resetForm,
-  };
+    const [errors, setErrors] = useState<Partial<ExpenseFormData>>({});
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const handleChange = (field: keyof ExpenseFormData, value: string) => {
+        setFormData((prev) => ({ ...prev, [field]: value }));
+        // Clear error for this field when user starts typing
+        if (errors[field]) {
+            setErrors((prev) => ({ ...prev, [field]: undefined }));
+        }
+    };
+
+    const validateForm = (): boolean => {
+        const newErrors: Partial<ExpenseFormData> = {};
+
+        if (!formData.amount || Number(formData.amount) <= 0) {
+            newErrors.amount = "Amount must be greater than 0";
+        }
+
+        if (!formData.description.trim()) {
+            newErrors.description = "Description is required";
+        }
+
+        if (!formData.category) {
+            newErrors.category = "Category is required";
+        }
+
+        if (!formData.date) {
+            newErrors.date = "Date is required";
+        } else if (formData.date > today) {
+            newErrors.date = "Future date is not allowed";
+        }
+
+        setErrors(newErrors);
+        return Object.keys(newErrors).length === 0;
+    };
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        if (!validateForm()) {
+            return;
+        }
+
+        setIsSubmitting(true);
+        try {
+            await onSubmit(formData);
+            // Reset form on success
+            setFormData({
+                amount: "",
+                description: "",
+                category: "",
+                date: formatDate(new Date()),
+            });
+            setErrors({});
+        } catch (error) {
+            console.error("Form submission error:", error);
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const resetForm = () => {
+        setFormData({
+            amount: initialData?.amount || "",
+            description: initialData?.description || "",
+            category: initialData?.category || "",
+            date: initialData?.date || formatDate(new Date()),
+        });
+        setErrors({});
+    };
+
+    return {
+        formData,
+        errors,
+        isSubmitting,
+        handleChange,
+        handleSubmit,
+        resetForm,
+    };
 }


### PR DESCRIPTION
## Summary
Prevents users to create expenses on future dates. Closes [#BONUS-001](https://github.com/iam7kei/likhait-technical-test/issues/7).

## Scope
This PR covers expense creation validation only. Update and delete functionality is outside the current ticket scope ([BONUS-001](https://github.com/iam7kei/likhait-technical-test/issues/37) and can be tracked as a follow-up.

## Current Limitations
- Date validation is limited to expense creation only
- Update is out of scope for this ticket ([BONUS-001](https://github.com/iam7kei/likhait-technical-test/issues/7))
- Error messages are limited to frontend validations

## What Changed
- Added frontend validation by passing a `max` props to the `date` form field
- Added additional validation in `handleSubmit` function inside `useExpenseForm` hook
- Added validation for future dates through the `expense` model
- Added `format_errors` helper function for the expense controller

## Architectural Decisions 
- Added both frontend and backend validation for a more robust validation

## Testing
1. Open the expense form
2. Select a future date
3. Verify if the future dates are disabled

## Notes
- No schema changes to existing expenses table

## Follow-up Suggestions
- **Improve backend error handling in `api.ts`**: Currently backend validation errors are thrown but only logged via `console.error`. Consider parsing `error.errors` in the catch block of `useExpenseForm` and calling `setErrors()` to surface field-level messages (e.g. `{ date: "cannot be in the future" }`) directly in the UI.
